### PR TITLE
a little Wait before initialize

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -332,7 +332,7 @@ end
 --                 EVENT HANDLERS                 --
 ----------------------------------------------------
 
-AddEventHandler(event, function() TriggerServerEvent('xperience:server:load') end)
+AddEventHandler(event, function() Wait(200) TriggerServerEvent('xperience:server:load') end)
 
 RegisterNetEvent('xperience:client:init', function(...) Xperience:Init(...) end)
 RegisterNetEvent('xperience:client:addXP', function(...) Xperience:AddXP(...) end)


### PR DESCRIPTION
For some reason if the initialization is executed instantly after loading, it doesn't load, I don't know why but at least it happens to me, it's weird but it doesn't receive the source correctly, with a simple wait the problem was solved and the interface loads perfectly. For those who have that problem, it should work for them.